### PR TITLE
Add SQL sandbox and progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ The main logic for chat will be found in the `Chat` component in `app/components
 - Function Calling Example: [http://localhost:3000/examples/function-calling](http://localhost:3000/examples/function-calling)
 - File Search Example: [http://localhost:3000/examples/file-search](http://localhost:3000/examples/file-search)
 - Full-featured Example: [http://localhost:3000/examples/all](http://localhost:3000/examples/all)
+- SQL Sandbox: [http://localhost:3000/entities/sandbox](http://localhost:3000/entities/sandbox)
 
 ### Main Components
 
 - `app/components/chat.tsx` - handles chat rendering, [streaming](https://platform.openai.com/docs/assistants/overview?context=with-streaming), and [function call](https://platform.openai.com/docs/assistants/tools/function-calling/quickstart?context=streaming&lang=node.js) forwarding
 - `app/components/file-viewer.tsx` - handles uploading, fetching, and deleting files for [file search](https://platform.openai.com/docs/assistants/tools/file-search)
+- `app/components/sql-sandbox.tsx` - lightweight in-browser SQL environment with exercise tracking
 
 ### Endpoints
 

--- a/app/components/sandbox.module.css
+++ b/app/components/sandbox.module.css
@@ -1,0 +1,52 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.runButton {
+  width: 80px;
+  align-self: flex-start;
+  background-color: #003366;
+  color: white;
+  border: none;
+  border-radius: 20px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.error {
+  color: red;
+}
+
+.exercises ul {
+  list-style: none;
+  padding: 0;
+}
+
+.exercises li {
+  margin-bottom: 6px;
+}
+
+.check {
+  margin-left: 6px;
+  color: green;
+}
+
+.done {
+  text-decoration: line-through;
+}

--- a/app/components/sql-sandbox.tsx
+++ b/app/components/sql-sandbox.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import initSqlJs, { Database } from "sql.js";
+import Editor from "@monaco-editor/react";
+import styles from "./sandbox.module.css";
+
+interface Exercise {
+  id: number;
+  question: string;
+  solution: string;
+}
+
+const exercises: Exercise[] = [
+  {
+    id: 1,
+    question: "List all employees in the Sales department",
+    solution: "SELECT * FROM Employees WHERE department = 'Sales';",
+  },
+  {
+    id: 2,
+    question: "Show the average salary per department",
+    solution: "SELECT department, AVG(salary) AS avg_salary FROM Employees GROUP BY department;",
+  },
+];
+
+export default function SQLSandbox() {
+  const [db, setDb] = useState<Database | null>(null);
+  const [query, setQuery] = useState("SELECT * FROM Employees;");
+  const [result, setResult] = useState<{ columns: string[]; values: any[][] } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    const init = async () => {
+      const SQL = await initSqlJs({ locateFile: (file) => `https://sql.js.org/dist/${file}` });
+      const db = new SQL.Database();
+      db.run(`
+        CREATE TABLE Employees (id INTEGER, name TEXT, department TEXT, salary INTEGER);
+        INSERT INTO Employees VALUES (1, 'Alice', 'Sales', 5000);
+        INSERT INTO Employees VALUES (2, 'Bob', 'Engineering', 7000);
+        INSERT INTO Employees VALUES (3, 'Charlie', 'Sales', 5500);
+        INSERT INTO Employees VALUES (4, 'Dana', 'HR', 4800);
+      `);
+      setDb(db);
+      const stored = localStorage.getItem("sql-progress");
+      if (stored) setProgress(JSON.parse(stored));
+    };
+    init();
+  }, []);
+
+  const runQuery = () => {
+    if (!db) return;
+    setError(null);
+    try {
+      const res = db.exec(query);
+      if (res.length) {
+        setResult({ columns: res[0].columns, values: res[0].values });
+      } else {
+        setResult(null);
+      }
+      checkExercises(query, res);
+    } catch (err: any) {
+      setError(err.message);
+      setResult(null);
+    }
+  };
+
+  const checkExercises = (q: string, res: any[]) => {
+    exercises.forEach((ex) => {
+      if (progress[ex.id]) return;
+      const normalized = q.replace(/\s+/g, " ").trim().toLowerCase();
+      const sol = ex.solution.replace(/\s+/g, " ").trim().toLowerCase();
+      if (normalized === sol) {
+        const updated = { ...progress, [ex.id]: true };
+        setProgress(updated);
+        localStorage.setItem("sql-progress", JSON.stringify(updated));
+      }
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <h2>SQL Sandbox</h2>
+      <Editor
+        height="150px"
+        defaultLanguage="sql"
+        value={query}
+        onChange={(val) => setQuery(val || "")}
+        options={{ fontSize: 14, minimap: { enabled: false } }}
+      />
+      <button className={styles.runButton} onClick={runQuery}>Run</button>
+      {error && <div className={styles.error}>{error}</div>}
+      {result && (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              {result.columns.map((c) => (
+                <th key={c}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {result.values.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{String(cell)}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <div className={styles.exercises}>
+        <h3>Exercises</h3>
+        <ul>
+          {exercises.map((ex) => (
+            <li key={ex.id} className={progress[ex.id] ? styles.done : ""}>
+              {ex.question}
+              {progress[ex.id] && <span className={styles.check}>✓</span>}
+            </li>
+          ))}
+        </ul>
+        <p>
+          Completed {Object.values(progress).filter(Boolean).length} of {exercises.length}
+          {" "}exercises
+        </p>
+      </div>
+    </div>
+  );
+}
+

--- a/app/entities/sandbox/page.tsx
+++ b/app/entities/sandbox/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import SQLSandbox from "../../components/sql-sandbox";
+
+export default function SandboxPage() {
+  return (
+    <div>
+      <SQLSandbox />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SQLSandbox` component for running sample SQL locally
- track user progress for sandbox exercises in local storage
- expose new sandbox page
- document sandbox page and component in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2ab60288329b0dee3e0bf7f61e9