### PR TITLE
Add SQL sandbox and image upload

### DIFF
--- a/app/api/assistants/files/route.tsx
+++ b/app/api/assistants/files/route.tsx
@@ -17,7 +17,7 @@ export async function POST(request) {
   await openai.beta.vectorStores.files.create(vectorStoreId, {
     file_id: openaiFile.id,
   });
-  return new Response();
+  return Response.json({ file_id: openaiFile.id });
 }
 
 // list files in assistant's vector store

--- a/app/api/assistants/threads/[threadId]/messages/route.ts
+++ b/app/api/assistants/threads/[threadId]/messages/route.ts
@@ -7,12 +7,23 @@ export const maxDuration = 50;
 
 // Send a new message to a thread
 export async function POST(request, { params: { threadId } }) {
-  const { content } = await request.json();
+  const { content, fileIds } = await request.json();
 
-  await openai.beta.threads.messages.create(threadId, {
-    role: "user",
-    content: content,
-  });
+  if (fileIds && fileIds.length > 0) {
+    const messageContent = [
+      ...fileIds.map((id) => ({ type: "image_file", image_file: { file_id: id, detail: "auto" } })),
+      { type: "text", text: content },
+    ];
+    await openai.beta.threads.messages.create(threadId, {
+      role: "user",
+      content: messageContent,
+    });
+  } else {
+    await openai.beta.threads.messages.create(threadId, {
+      role: "user",
+      content: content,
+    });
+  }
 
   const stream = openai.beta.threads.runs.stream(threadId, {
     assistant_id: assistantId,

--- a/app/components/chat.module.css
+++ b/app/components/chat.module.css
@@ -843,3 +843,35 @@
   transform: translateY(0);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
+
+.sandboxButton {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.sandboxButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  opacity: 0.9;
+}
+.sandboxButton:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.imageUploadButton {
+  background: linear-gradient(135deg, #006699 0%, #0088cc 100%);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.imageUploadButton:hover {
+  transform: scale(1.05);
+}

--- a/app/components/sql-sandbox.module.css
+++ b/app/components/sql-sandbox.module.css
@@ -1,0 +1,70 @@
+.container {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 600px;
+  margin: 0 auto;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+.title {
+  margin-bottom: 10px;
+  text-align: center;
+}
+.examples {
+  margin-bottom: 10px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.exampleButton {
+  background-color: #003366;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.exampleButton:hover {
+  background-color: #002244;
+}
+.queryInput {
+  width: 100%;
+  height: 80px;
+  margin-bottom: 10px;
+}
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.runButton {
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.closeButton {
+  background-color: #ccc;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.error {
+  color: red;
+  margin-bottom: 10px;
+}
+.results {
+  width: 100%;
+  border-collapse: collapse;
+}
+.results th,
+.results td {
+  border: 1px solid #ddd;
+  padding: 4px 8px;
+}
+.noResult {
+  margin-top: 5px;
+}

--- a/app/components/sql-sandbox.tsx
+++ b/app/components/sql-sandbox.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import initSqlJs from 'sql.js';
+import styles from './sql-sandbox.module.css';
+
+interface Props {
+  onClose: () => void;
+}
+
+interface QueryResult {
+  columns: string[];
+  values: any[][];
+}
+
+const SQLSandbox: React.FC<Props> = ({ onClose }) => {
+  const [db, setDb] = useState<any>(null);
+  const [query, setQuery] = useState('SELECT * FROM students;');
+  const [result, setResult] = useState<QueryResult | null>(null);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const init = async () => {
+      const SQL = await initSqlJs();
+      const database = new SQL.Database();
+      database.run(`
+        CREATE TABLE students(id INTEGER PRIMARY KEY, name TEXT, grade INTEGER);
+        INSERT INTO students VALUES (1,'Alice',90),(2,'Bob',85),(3,'Charlie',92);
+      `);
+      setDb(database);
+    };
+    init();
+  }, []);
+
+  const runQuery = () => {
+    if (!db) return;
+    try {
+      const res = db.exec(query);
+      if (res.length === 0) {
+        setResult({ columns: [], values: [] });
+      } else {
+        setResult({ columns: res[0].columns, values: res[0].values });
+      }
+      setError('');
+    } catch (err: any) {
+      setError(err.message);
+      setResult(null);
+    }
+  };
+
+  const examples = [
+    { label: 'All students', query: 'SELECT * FROM students;' },
+    { label: 'Top grades', query: 'SELECT name, grade FROM students WHERE grade > 90;' }
+  ];
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>SQL Sandbox</h2>
+      <div className={styles.examples}>
+        {examples.map((ex) => (
+          <button key={ex.label} onClick={() => setQuery(ex.query)} className={styles.exampleButton}>
+            {ex.label}
+          </button>
+        ))}
+      </div>
+      <textarea className={styles.queryInput} value={query} onChange={(e) => setQuery(e.target.value)} />
+      <div className={styles.actions}>
+        <button onClick={runQuery} className={styles.runButton}>Run</button>
+        <button onClick={onClose} className={styles.closeButton}>Close</button>
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+      {result && result.columns.length > 0 && (
+        <table className={styles.results}>
+          <thead>
+            <tr>
+              {result.columns.map((c) => (
+                <th key={c}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {result.values.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{String(cell)}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {result && result.columns.length === 0 && (
+        <div className={styles.noResult}>Query executed.</div>
+      )}
+    </div>
+  );
+};
+
+export default SQLSandbox;


### PR DESCRIPTION
## Summary
- integrate an in-browser SQL sandbox so users can try queries
- allow uploading screenshot images directly in chat
- support sending uploaded files to the assistant
- tweak chat styles for new sandbox and image buttons
- return file id when uploading files

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684801b8035c8329a3ed69e20158256a