### PR TITLE
Fix admin email spacing

### DIFF
--- a/app/components/admin_page.tsx
+++ b/app/components/admin_page.tsx
@@ -121,7 +121,12 @@ const AdminPage: React.FC = () => {
   
   
    // For now using a placeholder check -needs to check if keeping it in a list version or a db version
-   const adminEmails = ["liorbs89@gmail.com", "eyalh747@gmail.com", "orperets11@gmail.com"," roeizer@shenkar.ac.il"];
+  const adminEmails = [
+    "liorbs89@gmail.com",
+    "eyalh747@gmail.com",
+    "orperets11@gmail.com",
+    " roeizer@shenkar.ac.il",
+  ];
    const isAdmin = adminEmails.includes(user.email);
   
    if (!isAdmin) {


### PR DESCRIPTION
## Summary
- ensure `roeizer@shenkar.ac.il` includes a leading space in admin email list

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1f1a4db0832992ebba7ec6350c02