### PR TITLE
Close admin mobile sidebar on navigation and improve AI Model Management UI clarity

### DIFF
--- a/app/admin/model-management/ModelManagement.module.css
+++ b/app/admin/model-management/ModelManagement.module.css
@@ -23,6 +23,65 @@
   font-size: 1.1rem;
 }
 
+.overviewSection {
+  background: linear-gradient(180deg, #f5fbff 0%, #ffffff 100%);
+  border: 1px solid #d9ebfa;
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.overviewSection h2 {
+  margin: 0 0 0.75rem;
+  color: #145b90;
+  font-size: 1.15rem;
+}
+
+.overviewGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.overviewCard {
+  background: #fff;
+  border: 1px solid #dfeaf2;
+  border-radius: 10px;
+  padding: 0.75rem;
+}
+
+.overviewLabel {
+  display: block;
+  color: #4f6475;
+  font-size: 0.82rem;
+  margin-bottom: 0.2rem;
+}
+
+.overviewValue {
+  color: #12344c;
+  font-size: 1rem;
+}
+
+.helperText {
+  margin: 0.75rem 0 0;
+  color: #486175;
+  font-size: 0.9rem;
+}
+
+.quickGuide {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.quickGuideItem {
+  background: #f8f9fa;
+  border: 1px solid #e7ebef;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: #2f3f4a;
+}
+
 .navigation {
   margin-bottom: 2rem;
 }
@@ -319,5 +378,9 @@
   
   .analytics {
     grid-template-columns: 1fr;
+  }
+
+  .header h1 {
+    font-size: 2rem;
   }
 }

--- a/app/admin/model-management/page.tsx
+++ b/app/admin/model-management/page.tsx
@@ -114,6 +114,15 @@ export default function ModelManagement() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const runtimeStatusItems = runtimeConfig
+    ? [
+        { label: "מצב API", value: apiMode },
+        { label: "מודל פעיל", value: runtimeConfig.model },
+        { label: "כלים פעילים", value: String(runtimeConfig.toolsCount) },
+        { label: "מקור קונפיגורציה", value: runtimeConfig.source || "default" },
+      ]
+    : [];
+
   useEffect(() => {
     void loadRuntimeConfig();
     void loadUsageAnalytics();
@@ -250,7 +259,38 @@ export default function ModelManagement() {
 
       <div className={styles.header}>
         <h1>ניהול מודלי AI</h1>
-        <p>ניהול קונפיגורציית OpenAI runtime עבור Michael על גבי Responses API. נתיבי ה-Assistants נשארים כ-aliases זמניים בלבד.</p>
+        <p>
+          מסך זה מרכז את מצב ה-runtime, בדיקות תקינות, פיצ׳רים וסטטיסטיקות שימוש - כדי להבין מהר מה פעיל כרגע ומה דורש טיפול.
+        </p>
+      </div>
+
+      {runtimeConfig ? (
+        <section className={styles.overviewSection}>
+          <h2>מה קיים במסך הזה?</h2>
+          <div className={styles.overviewGrid}>
+            {runtimeStatusItems.map((item) => (
+              <div key={item.label} className={styles.overviewCard}>
+                <span className={styles.overviewLabel}>{item.label}</span>
+                <strong className={styles.overviewValue}>{item.value}</strong>
+              </div>
+            ))}
+          </div>
+          <p className={styles.helperText}>
+            עדכון אחרון: {runtimeConfig.updatedAt || "לא זמין"} · מודל מומלץ כעת: {RECOMMENDED_RUNTIME_MODEL}
+          </p>
+        </section>
+      ) : null}
+
+      <div className={styles.quickGuide}>
+        <div className={styles.quickGuideItem}>
+          <strong>1) אימות מצב:</strong> התחילו ב״קונפיגורציית Runtime נוכחית״ כדי לבדוק מודל וכלים פעילים.
+        </div>
+        <div className={styles.quickGuideItem}>
+          <strong>2) בדיקות תקינות:</strong> הריצו בדיקות Runtime כדי לוודא איכות תגובה, עברית ו-Tools.
+        </div>
+        <div className={styles.quickGuideItem}>
+          <strong>3) ניטור שימוש:</strong> עברו ל״ניתוח שימוש״ כדי לזהות עומסים ועלויות.
+        </div>
       </div>
 
       {error && <div className={styles.error}>Error: {error}</div>}

--- a/app/components/admin/ModernAdminLayout.tsx
+++ b/app/components/admin/ModernAdminLayout.tsx
@@ -79,6 +79,11 @@ export default function ModernAdminLayout({
         <Sidebar
           isCollapsed={!isMobile && isSidebarCollapsed}
           onToggleCollapse={handleToggleSidebar}
+          onNavigate={() => {
+            if (isMobile) {
+              setIsMobileMenuOpen(false);
+            }
+          }}
           currentUser={currentUser}
           onLogout={onLogout}
         />

--- a/app/components/admin/Sidebar.tsx
+++ b/app/components/admin/Sidebar.tsx
@@ -14,6 +14,7 @@ import styles from "./Sidebar.module.css";
 interface SidebarProps {
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  onNavigate?: () => void;
   currentUser?: string | null;
   onLogout: () => void;
 }
@@ -21,6 +22,7 @@ interface SidebarProps {
 export default function Sidebar({
   isCollapsed,
   onToggleCollapse,
+  onNavigate,
   currentUser,
   onLogout,
 }: SidebarProps) {
@@ -72,6 +74,7 @@ export default function Sidebar({
                     <Link
                       key={route.id}
                       href={route.href}
+                      onClick={onNavigate}
                       className={`${styles.navLink} ${isActive ? styles.navLinkActive : ""} ${
                         isCollapsed ? styles.navLinkCollapsed : ""
                       }`}


### PR DESCRIPTION
### Motivation
- Fix a mobile UX issue where the admin sidebar remained open after tapping a route and obscured the selected page. 
- Make the admin "ניהול מודלי AI" page clearer and easier to scan so admins can quickly see runtime status and next steps.

### Description
- Wire an `onNavigate` callback from `ModernAdminLayout` into `Sidebar` so route clicks call back to the layout and close the mobile drawer when on a mobile breakpoint (`app/components/admin/ModernAdminLayout.tsx`, `app/components/admin/Sidebar.tsx`).
- Add `onClick={onNavigate}` to admin route links so tapping a navigation item triggers the mobile-close behavior (`app/components/admin/Sidebar.tsx`).
- Enhance the AI Model Management page with a concise purpose paragraph, a runtime overview card grid (API mode, active model, enabled tools, config source), a last-updated + recommended model helper line, and a short 3-step quick guide for admins (`app/admin/model-management/page.tsx`).
- Add styles for the new overview and guide blocks and small responsive polish in the model-management stylesheet (`app/admin/model-management/ModelManagement.module.css`).

### Testing
- Ran a scoped ESLint invocation against the touched files which surfaced pre-existing repository lint issues and a CSS parser error under the lint invocation; the lint run exited with errors (these appear unrelated to the new logic and come from repo-wide rules and parser configuration). 
- No unit or end-to-end tests were executed for these changes in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccbe9be4c083299e1034cbb75f21da)