### PR TITLE
Remove "הצג פתרון" button from homework runner

### DIFF
--- a/app/homework/runner/[setId]/RunnerClient.tsx
+++ b/app/homework/runner/[setId]/RunnerClient.tsx
@@ -1036,14 +1036,6 @@ export function RunnerClient({ setId, studentId }: RunnerClientProps) {
                 >
                   הבאה ←
                 </button>
-                <button
-                  type="button"
-                  className={styles.showAnswerButton}
-                  onClick={() => activeQuestionId && handleShowAnswer(activeQuestionId)}
-                  disabled={!activeQuestionId}
-                >
-                  הצג פתרון
-                </button>
               </div>
               
               <button


### PR DESCRIPTION
### Motivation
- Prevent students from opening the official-solution modal from the runner screen by removing the `הצג פתרון` action in the question navigation controls.

### Description
- Deleted the `הצג פתרון` button and its click entry from the navigation action row in `app/homework/runner/[setId]/RunnerClient.tsx`.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38d685a788329a78469befecfeabe)