### PR TITLE
Add talushka7@gmail.com to homework access admins

### DIFF
--- a/__tests__/lib/deadline-utils.test.ts
+++ b/__tests__/lib/deadline-utils.test.ts
@@ -28,8 +28,10 @@ describe('deadline-utils availability windows', () => {
 
     expect(isHomeworkAccessAdmin('orperets11@gmail.com')).toBe(true);
     expect(isHomeworkAccessAdmin('roeizer@shenkar.ac.il')).toBe(true);
+    expect(isHomeworkAccessAdmin('talushka7@gmail.com')).toBe(true);
     expect(getAvailabilityState(homework, 'orperets11@gmail.com', now)).toBe('open');
     expect(isHomeworkAccessible(homework, 'roeizer@shenkar.ac.il', now)).toBe(true);
+    expect(getAvailabilityState(homework, 'talushka7@gmail.com', now)).toBe('open');
   });
 
   it('treats legacy dueAt-only homework as open before the deadline', () => {

--- a/lib/deadline-utils.ts
+++ b/lib/deadline-utils.ts
@@ -28,6 +28,7 @@ const EXTENDED_DEADLINE_USERS = [
 const HOMEWORK_ACCESS_ADMIN_EMAILS = [
   'orperets11@gmail.com',
   'roeizer@shenkar.ac.il',
+  'talushka7@gmail.com',
 ] as const;
 
 // Extension duration in milliseconds (2 days)


### PR DESCRIPTION
### Motivation
- Allow `talushka7@gmail.com` to bypass student availability windows and access `/homework/start` at any time like the other admins.

### Description
- Added `talushka7@gmail.com` to the `HOMEWORK_ACCESS_ADMIN_EMAILS` list in `lib/deadline-utils.ts` and updated `__tests__/lib/deadline-utils.test.ts` to assert this email is recognized and treated as having open access.

### Testing
- Ran `npm test -- __tests__/lib/deadline-utils.test.ts` and the suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1492b620848329b8bbb60c53be862c)